### PR TITLE
Changed colors and auto-pair of brackets/quotes

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -18,7 +18,7 @@ exports.setup = function (editor, view) {
   outputView = document.getElementById('output-view');
 
   defaultEditorSettings = {
-    theme: 'ace/theme/chrome',
+    theme: 'ace/theme/github',
     fontSize: 14,
     tabSize: 4,
     foldStyle: 'markbegin',
@@ -90,6 +90,7 @@ exports.setup = function (editor, view) {
     editor.setShowInvisibles(showInvisibles);
     editor.setDisplayIndentGuides(displayIndentGuides);
     editor.renderer.setShowGutter(showGutter);
+    editor.setBehavioursEnabled(false);
 
     themeOption.find('option:eq(' + theme + ')').prop('selected', true);
     fontsizeOption.find('option:eq(' + fontSize + ')').prop('selected', true);


### PR DESCRIPTION
Changed the default color scheme to get rid of solid red
background color when quotes are not paired. Turned off the
auto-pairing of brackets and quotes