### PR TITLE
Resolves Auto-pair bracket clash

### DIFF
--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -639,15 +639,19 @@ function setupCharacterEquivalencies(editor) {
           var leftText = editor.session.getTextRange(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column));
           var rightText = editor.session.getTextRange(new Range(cursor.row, cursor.column, cursor.row, cursor.column + 2));
 
+
           if (leftText === '[[' && rightText === ']]') {
+            var leftReplacement = replacements[leftText];
+            var rightReplacement = replacements[rightText];
+            
             var autoPairActive = editor.getBehavioursEnabled();
             if (autoPairActive) {
               // Replace both sides of the cursor with ⟦ and ⟧
-              editor.session.replace(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column + 2), '⟦⟧');
+              editor.session.replace(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column + 2), leftReplacement+rightReplacement);
               editor.navigateLeft(1); // Navigate cursor between the ⟦ and ⟧ symbol
             } else {
               // Insert ⟦⟧ normally
-              editor.session.replace(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column + 2), '⟦⟧');
+              editor.session.replace(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column + 2), leftReplacement+rightReplacement);
             }
           }
           else if (text in replacements) {

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -615,6 +615,10 @@ function setupCharacterEquivalencies(editor) {
       addCharEq(finalChars[i]);
   }
 
+  var bracket_replacements =   {     // dictionary of replacements for bracket clash in the editor
+    "[[":"⟦",
+    "]]":"⟧"
+};
   function addCharEq(a) {
 
     editor.commands.addCommand({
@@ -633,16 +637,12 @@ function setupCharacterEquivalencies(editor) {
         if (cursor.column >= 2) {
           // Get the range and the text
           var replacementRange = new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column);
-          var text = editor.session.getTextRange(replacementRange);
-          
-          // Get the left and right substrings
-          var leftText = editor.session.getTextRange(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column));
+          var leftText = editor.session.getTextRange(replacementRange);
           var rightText = editor.session.getTextRange(new Range(cursor.row, cursor.column, cursor.row, cursor.column + 2));
 
-
-          if (leftText === '[[' && rightText === ']]') {
-            var leftReplacement = replacements[leftText];
-            var rightReplacement = replacements[rightText];
+          if (bracket_replacements.hasOwnProperty(leftText) && bracket_replacements.hasOwnProperty(rightText)) {            
+            var leftReplacement = bracket_replacements[leftText];
+            var rightReplacement = bracket_replacements[rightText];
             
             var autoPairActive = editor.getBehavioursEnabled();
             if (autoPairActive) {
@@ -654,9 +654,9 @@ function setupCharacterEquivalencies(editor) {
               editor.session.replace(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column + 2), leftReplacement+rightReplacement);
             }
           }
-          else if (text in replacements) {
+          else if (leftText in replacements) {
                 //Insert the matching symbol
-                editor.session.replace(replacementRange, replacements[text]);
+                editor.session.replace(replacementRange, replacements[leftText]);
           }
         }
       },

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -616,30 +616,47 @@ function setupCharacterEquivalencies(editor) {
   }
 
   function addCharEq(a) {
+
     editor.commands.addCommand({
-      name: 'myCommand'+a,
-      bindKey: {win: a,  mac: a},
-      exec: function(editor) {
-        //Insert `a` to support standard functionality
+      name: 'myCommand' + a,
+      bindKey: { win: a, mac: a },
+      exec: function (editor) {
+        // Insert 'a' to support standard functionality
         editor.insert(a);
-
-        cursorMoved = false;    // to allow backspace replacement
-
-        //Calculate the cursor position
+  
+        cursorMoved = false; // To allow backspace replacement
+  
+        // Calculate the cursor position
         var cursor = editor.getCursorPosition();
-
-        //Check if replacement is possible
+  
+        // Check if replacement is possible
         if (cursor.column >= 2) {
-          //Get the range and the text
-          var replacementRange = new Range(cursor.row, cursor.column-2, cursor.row, cursor.column);
+          // Get the range and the text
+          var replacementRange = new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column);
           var text = editor.session.getTextRange(replacementRange);
-          if (text in replacements) {
-            //Insert the matching symbol
-            editor.session.replace(replacementRange, replacements[text]);
+          
+          // Get the left and right substrings
+          var leftText = editor.session.getTextRange(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column));
+          var rightText = editor.session.getTextRange(new Range(cursor.row, cursor.column, cursor.row, cursor.column + 2));
+
+          if (leftText === '[[' && rightText === ']]') {
+            var autoPairActive = editor.getBehavioursEnabled();
+            if (autoPairActive) {
+              // Replace both sides of the cursor with ⟦ and ⟧
+              editor.session.replace(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column + 2), '⟦⟧');
+              editor.navigateLeft(1); // Navigate cursor between the ⟦ and ⟧ symbol
+            } else {
+              // Insert ⟦⟧ normally
+              editor.session.replace(new Range(cursor.row, cursor.column - 2, cursor.row, cursor.column + 2), '⟦⟧');
+            }
+          }
+          else if (text in replacements) {
+                //Insert the matching symbol
+                editor.session.replace(replacementRange, replacements[text]);
           }
         }
       },
-      readOnly: false // false if this command should not apply in readOnly mode
+      readOnly: false, // False if this command should not apply in readOnly mode
     });
   }
 


### PR DESCRIPTION
I changed the code in editor.js so that when the Autopair setting is turned on and two brackets '[[' are typed in, the replacement from '[[' to '⟦' occurs on the left side along with ']]' to '⟧' on the right side. Everything else operates same as before.